### PR TITLE
feat: add mongodb integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+MONGODB_URI=""
+APP_BASE_URL=""

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.0"
+    "next": "15.5.0",
+    "mongoose": "^8.0.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { connect } from "@/lib/db";
+import { Customer } from "@/models/Customer";
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    await connect();
+    const customer = await Customer.create(data);
+    return NextResponse.json(customer, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Failed to create customer" }, { status: 500 });
+  }
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { connect } from "@/lib/db";
+import { SearchRequest } from "@/models/SearchRequest";
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    await connect();
+    const search = await SearchRequest.create(data);
+    return NextResponse.json(search, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Failed to save search" }, { status: 500 });
+  }
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  MONGODB_URI: z.string().min(1),
+  APP_BASE_URL: z.string().url(),
+});
+
+export const env = envSchema.parse(process.env);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,25 @@
+import mongoose from "mongoose";
+import { env } from "@/env";
+
+type MongooseCache = {
+  conn: typeof mongoose | null;
+  promise: Promise<typeof mongoose> | null;
+};
+
+const globalWithMongoose = global as typeof globalThis & {
+  mongoose?: MongooseCache;
+};
+
+if (!globalWithMongoose.mongoose) {
+  globalWithMongoose.mongoose = { conn: null, promise: null };
+}
+
+export async function connect() {
+  const cache = globalWithMongoose.mongoose!;
+  if (cache.conn) return cache.conn;
+  if (!cache.promise) {
+    cache.promise = mongoose.connect(env.MONGODB_URI);
+  }
+  cache.conn = await cache.promise;
+  return cache.conn;
+}

--- a/src/models/Customer.ts
+++ b/src/models/Customer.ts
@@ -1,0 +1,12 @@
+import { Schema, model, models } from "mongoose";
+
+const customerSchema = new Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+export const Customer = models.Customer || model("Customer", customerSchema);
+export type CustomerDocument = typeof Customer extends import("mongoose").Model<infer T> ? T : never;

--- a/src/models/EmailLog.ts
+++ b/src/models/EmailLog.ts
@@ -1,0 +1,14 @@
+import { Schema, model, models } from "mongoose";
+
+const emailLogSchema = new Schema(
+  {
+    to: { type: String, required: true },
+    subject: { type: String, required: true },
+    body: { type: String },
+    sentAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+export const EmailLog = models.EmailLog || model("EmailLog", emailLogSchema);
+export type EmailLogDocument = typeof EmailLog extends import("mongoose").Model<infer T> ? T : never;

--- a/src/models/SearchRequest.ts
+++ b/src/models/SearchRequest.ts
@@ -1,0 +1,15 @@
+import { Schema, model, models } from "mongoose";
+
+const searchRequestSchema = new Schema(
+  {
+    customer: { type: Schema.Types.ObjectId, ref: "Customer" },
+    origin: { type: String, required: true },
+    destination: { type: String, required: true },
+    date: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+export const SearchRequest =
+  models.SearchRequest || model("SearchRequest", searchRequestSchema);
+export type SearchRequestDocument = typeof SearchRequest extends import("mongoose").Model<infer T> ? T : never;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,0 +1,12 @@
+import { Schema, model, models } from "mongoose";
+
+const userSchema = new Schema(
+  {
+    name: { type: String },
+    email: { type: String, required: true, unique: true },
+  },
+  { timestamps: true }
+);
+
+export const User = models.User || model("User", userSchema);
+export type UserDocument = typeof User extends import("mongoose").Model<infer T> ? T : never;


### PR DESCRIPTION
## Summary
- add mongoose and zod dependencies
- add cached connection helper and models for User, Customer, SearchRequest, EmailLog
- create env validation and API routes for customers and search

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: module not found for mongoose and zod)


------
https://chatgpt.com/codex/tasks/task_e_68ab4b7184088332a58e64948b1eb0e7