### PR TITLE
Add GET endpoints for customer and search APIs and refine DB connection

### DIFF
--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -2,6 +2,20 @@ import { NextRequest, NextResponse } from "next/server";
 import { connect } from "@/lib/db";
 import { Customer } from "@/models/Customer";
 
+export async function GET() {
+  try {
+    await connect();
+    const customers = await Customer.find();
+    return NextResponse.json(customers);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Failed to fetch customers" },
+      { status: 500 }
+    );
+  }
+}
+
 export async function POST(req: NextRequest) {
   try {
     const data = await req.json();
@@ -10,6 +24,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(customer, { status: 201 });
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ error: "Failed to create customer" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to create customer" },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -2,6 +2,20 @@ import { NextRequest, NextResponse } from "next/server";
 import { connect } from "@/lib/db";
 import { SearchRequest } from "@/models/SearchRequest";
 
+export async function GET() {
+  try {
+    await connect();
+    const searches = await SearchRequest.find().populate("customer");
+    return NextResponse.json(searches);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Failed to fetch searches" },
+      { status: 500 }
+    );
+  }
+}
+
 export async function POST(req: NextRequest) {
   try {
     const data = await req.json();
@@ -10,6 +24,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(search, { status: 201 });
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ error: "Failed to save search" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to save search" },
+      { status: 500 }
+    );
   }
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,13 +10,12 @@ const globalWithMongoose = global as typeof globalThis & {
   mongoose?: MongooseCache;
 };
 
-if (!globalWithMongoose.mongoose) {
-  globalWithMongoose.mongoose = { conn: null, promise: null };
-}
-
 export async function connect() {
-  const cache = globalWithMongoose.mongoose!;
-  if (cache.conn) return cache.conn;
+  const cache =
+    globalWithMongoose.mongoose ??= { conn: null, promise: null };
+  if (cache.conn) {
+    return cache.conn;
+  }
   if (!cache.promise) {
     cache.promise = mongoose.connect(env.MONGODB_URI);
   }


### PR DESCRIPTION
## Summary
- add GET handlers to list customers and search requests
- streamline MongoDB connection caching in db helper

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: Cannot find module 'mongoose', 'zod')*
- `npm install mongoose zod` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab52a22b84833290621fa0d199f866