### PR TITLE
feat: add dashboard and customer search UI

### DIFF
--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -6,11 +6,11 @@ export async function GET() {
   try {
     await connect();
     const customers = await Customer.find();
-    return NextResponse.json(customers);
+    return NextResponse.json({ ok: true, customers });
   } catch (error) {
     console.error(error);
     return NextResponse.json(
-      { error: "Failed to fetch customers" },
+      { ok: false, error: "Failed to fetch customers" },
       { status: 500 }
     );
   }
@@ -21,11 +21,11 @@ export async function POST(req: NextRequest) {
     const data = await req.json();
     await connect();
     const customer = await Customer.create(data);
-    return NextResponse.json(customer, { status: 201 });
+    return NextResponse.json({ ok: true, customer }, { status: 201 });
   } catch (error) {
     console.error(error);
     return NextResponse.json(
-      { error: "Failed to create customer" },
+      { ok: false, error: "Failed to create customer" },
       { status: 500 }
     );
   }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -6,11 +6,11 @@ export async function GET() {
   try {
     await connect();
     const searches = await SearchRequest.find().populate("customer");
-    return NextResponse.json(searches);
+    return NextResponse.json({ ok: true, searches });
   } catch (error) {
     console.error(error);
     return NextResponse.json(
-      { error: "Failed to fetch searches" },
+      { ok: false, error: "Failed to fetch searches" },
       { status: 500 }
     );
   }
@@ -21,11 +21,14 @@ export async function POST(req: NextRequest) {
     const data = await req.json();
     await connect();
     const search = await SearchRequest.create(data);
-    return NextResponse.json(search, { status: 201 });
+    return NextResponse.json(
+      { ok: true, id: search._id.toString(), search },
+      { status: 201 }
+    );
   } catch (error) {
     console.error(error);
     return NextResponse.json(
-      { error: "Failed to save search" },
+      { ok: false, error: "Failed to save search" },
       { status: 500 }
     );
   }

--- a/src/app/customers/CustomersClient.tsx
+++ b/src/app/customers/CustomersClient.tsx
@@ -1,0 +1,92 @@
+'use client';
+import { useState } from 'react';
+import CustomerForm from '@/components/CustomerForm';
+
+type Customer = { id: string; name: string; email: string; phone: string };
+
+type Props = {
+  initial: Customer[];
+};
+
+export default function CustomersClient({ initial }: Props) {
+  const [customers, setCustomers] = useState(initial);
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [showForm, setShowForm] = useState(false);
+
+  const filtered = customers.filter(
+    (c) =>
+      c.name.toLowerCase().includes(query.toLowerCase()) ||
+      c.email.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const pageSize = 20;
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const current = filtered.slice((page - 1) * pageSize, page * pageSize);
+
+  return (
+    <div>
+      <div className="flex justify-between mb-4">
+        <input
+          className="border p-2 rounded flex-1 mr-2"
+          placeholder="Search"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setPage(1);
+          }}
+        />
+        <button
+          className="bg-green-600 text-white px-4 py-2 rounded"
+          onClick={() => setShowForm(true)}
+        >
+          Add Customer
+        </button>
+      </div>
+      {current.length ? (
+        <ul className="space-y-2">
+          {current.map((c) => (
+            <li key={c.id} className="border p-2 rounded">
+              {c.name} - {c.email}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No customers</p>
+      )}
+      {totalPages > 1 && (
+        <div className="mt-4 space-x-2">
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
+            <button
+              key={n}
+              className={`px-3 py-1 border ${
+                n === page ? 'bg-blue-600 text-white' : 'bg-white'
+              }`}
+              onClick={() => setPage(n)}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      )}
+      {showForm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <div className="bg-white p-4 rounded w-80">
+            <CustomerForm
+              onCreated={(c) => {
+                setCustomers([c, ...customers]);
+                setShowForm(false);
+              }}
+            />
+            <button
+              className="mt-2 text-sm text-gray-500"
+              onClick={() => setShowForm(false)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/customers/page.tsx
+++ b/src/app/customers/page.tsx
@@ -1,0 +1,15 @@
+import { connect } from '@/lib/db';
+import { Customer } from '@/models/Customer';
+import CustomersClient from './CustomersClient';
+
+export default async function CustomersPage() {
+  await connect();
+  const customers = await Customer.find().sort({ createdAt: -1 }).lean();
+  const list = customers.map((c: any) => ({
+    id: c._id.toString(),
+    name: c.name,
+    email: c.email,
+    phone: c.phone,
+  }));
+  return <CustomersClient initial={list} />;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,66 @@
+import { connect } from '@/lib/db';
+import { Customer } from '@/models/Customer';
+import { SearchRequest } from '@/models/SearchRequest';
+import CustomerForm from '@/components/CustomerForm';
+import SearchForm from '@/components/SearchForm';
+
+export default async function DashboardPage() {
+  await connect();
+  const customers = await Customer.find().sort({ name: 1 }).lean();
+  const recentCustomers = await Customer.find()
+    .sort({ createdAt: -1 })
+    .limit(10)
+    .lean();
+  const recentSearches = await SearchRequest.find()
+    .sort({ createdAt: -1 })
+    .limit(10)
+    .populate('customer')
+    .lean();
+
+  const customerOpts = customers.map((c: any) => ({
+    id: c._id.toString(),
+    name: c.name,
+    email: c.email,
+  }));
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <h2 className="font-semibold text-lg mb-2">Add Customer</h2>
+        <CustomerForm />
+      </section>
+      <section>
+        <h2 className="font-semibold text-lg mb-2">Quick Search</h2>
+        <SearchForm customers={customerOpts} />
+      </section>
+      <section>
+        <h2 className="font-semibold text-lg mb-2">Recent Customers</h2>
+        {recentCustomers.length ? (
+          <ul className="list-disc ml-5">
+            {recentCustomers.map((c: any) => (
+              <li key={c._id.toString()}>
+                {c.name} - {c.email}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No customers</p>
+        )}
+      </section>
+      <section>
+        <h2 className="font-semibold text-lg mb-2">Recent Searches</h2>
+        {recentSearches.length ? (
+          <ul className="list-disc ml-5">
+            {recentSearches.map((s: any) => (
+              <li key={s._id.toString()}>
+                {s.customer?.name || 'Unknown'}: {s.origin} → {s.destination}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No searches</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="p-4">
+      <h2 className="text-red-600 font-semibold mb-2">Something went wrong!</h2>
+      <p className="mb-2">{error.message}</p>
+      <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={() => reset()}>
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Link from "next/link";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +25,35 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}> 
+        <nav className="bg-blue-600 text-white px-4 py-2 font-bold">Flight Agent AI</nav>
+        <div className="flex min-h-screen">
+          <aside className="w-48 bg-gray-100 p-4 space-y-2">
+            <ul className="space-y-2">
+              <li>
+                <Link href="/dashboard" className="block hover:underline">
+                  Dashboard
+                </Link>
+              </li>
+              <li>
+                <Link href="/customers" className="block hover:underline">
+                  Customers
+                </Link>
+              </li>
+              <li>
+                <Link href="/searches" className="block hover:underline">
+                  Searches
+                </Link>
+              </li>
+              <li>
+                <Link href="/settings" className="block hover:underline">
+                  Settings
+                </Link>
+              </li>
+            </ul>
+          </aside>
+          <main className="flex-1 p-4">{children}</main>
+        </div>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,17 @@
-import Image from "next/image";
+import Link from 'next/link';
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+    <div className="p-8 space-y-4">
+      <h1 className="text-2xl font-bold">Welcome to Flight Agent AI</h1>
+      <div className="space-x-4">
+        <Link href="/dashboard" className="bg-blue-600 text-white px-4 py-2 rounded">
+          Go to Dashboard
+        </Link>
+        <Link href="/customers" className="bg-green-600 text-white px-4 py-2 rounded">
+          Add Customer
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/app/searches/SearchesClient.tsx
+++ b/src/app/searches/SearchesClient.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { useState } from 'react';
+
+type Search = {
+  id: string;
+  customer?: { name: string };
+  origin: string;
+  destination: string;
+  earliestDate: string;
+  latestDate: string;
+  passengers: number;
+  cabin: string;
+  status: string;
+  createdAt: string;
+};
+
+type Props = {
+  initial: Search[];
+};
+
+export default function SearchesClient({ initial }: Props) {
+  const [selected, setSelected] = useState<Search | null>(null);
+
+  return (
+    <div className="flex flex-col md:flex-row gap-4">
+      <table className="min-w-full text-sm border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 border">Customer</th>
+            <th className="p-2 border">Route</th>
+            <th className="p-2 border">Dates</th>
+            <th className="p-2 border">Pax</th>
+            <th className="p-2 border">Cabin</th>
+            <th className="p-2 border">Status</th>
+            <th className="p-2 border">Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {initial.length ? (
+            initial.map((s) => (
+              <tr
+                key={s.id}
+                className="cursor-pointer hover:bg-gray-100"
+                onClick={() => setSelected(s)}
+              >
+                <td className="p-2 border">{s.customer?.name || 'Unknown'}</td>
+                <td className="p-2 border">
+                  {s.origin} → {s.destination}
+                </td>
+                <td className="p-2 border">
+                  {s.earliestDate} - {s.latestDate}
+                </td>
+                <td className="p-2 border">{s.passengers}</td>
+                <td className="p-2 border">{s.cabin}</td>
+                <td className="p-2 border">{s.status}</td>
+                <td className="p-2 border">
+                  {new Date(s.createdAt).toLocaleString()}
+                </td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td className="p-2" colSpan={7}>
+                No searches
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      {selected && (
+        <div className="md:w-1/2 border p-4">
+          <h3 className="font-semibold mb-2">Details</h3>
+          <pre className="text-xs overflow-auto">
+            {JSON.stringify(selected, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/searches/page.tsx
+++ b/src/app/searches/page.tsx
@@ -1,0 +1,25 @@
+import { connect } from '@/lib/db';
+import { SearchRequest } from '@/models/SearchRequest';
+import SearchesClient from './SearchesClient';
+
+export default async function SearchesPage() {
+  await connect();
+  const searches = await SearchRequest.find()
+    .sort({ createdAt: -1 })
+    .limit(50)
+    .populate('customer')
+    .lean();
+  const list = searches.map((s: any) => ({
+    id: s._id.toString(),
+    customer: s.customer ? { name: s.customer.name } : undefined,
+    origin: s.origin,
+    destination: s.destination,
+    earliestDate: s.earliestDate,
+    latestDate: s.latestDate,
+    passengers: s.passengers,
+    cabin: s.cabin,
+    status: s.status,
+    createdAt: s.createdAt.toISOString(),
+  }));
+  return <SearchesClient initial={list} />;
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,26 @@
+import { env } from '@/env';
+
+export default function SettingsPage() {
+  const emailFrom = process.env.EMAIL_FROM || 'not set';
+  return (
+    <div className="space-y-4">
+      <div className="p-4 border rounded">
+        <h2 className="font-semibold">Subscription Status</h2>
+        <p>Coming soon</p>
+      </div>
+      <div className="p-4 border rounded">
+        <h2 className="font-semibold">API Keys</h2>
+        <p>Coming soon</p>
+      </div>
+      <div className="p-4 border rounded">
+        <h2 className="font-semibold">Email From Address</h2>
+        <p>{emailFrom}</p>
+      </div>
+      <div className="p-4 border rounded">
+        <h2 className="font-semibold">Environment</h2>
+        <p>NODE_ENV: {process.env.NODE_ENV}</p>
+        <p>APP_BASE_URL: {env.APP_BASE_URL}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CustomerForm.tsx
+++ b/src/components/CustomerForm.tsx
@@ -1,0 +1,87 @@
+'use client';
+import { useState } from 'react';
+import Toast from './Toast';
+
+type Props = {
+  onCreated?: (customer: any) => void;
+};
+
+export default function CustomerForm({ onCreated }: Props) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name || !email || !phone) {
+      setToast({ message: 'All fields required', type: 'error' });
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch('/api/customers', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-user-email': 'agent@example.com',
+        },
+        body: JSON.stringify({ name, email, phone }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setToast({ message: 'Customer added', type: 'success' });
+        setName('');
+        setEmail('');
+        setPhone('');
+        onCreated?.(data.customer);
+      } else {
+        setToast({ message: data.error || 'Error', type: 'error' });
+      }
+    } catch (err) {
+      setToast({ message: 'Network error', type: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="relative">
+      {toast && (
+        <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />
+      )}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Phone"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          required
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        >
+          {loading ? 'Saving...' : 'Add Customer'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -1,0 +1,146 @@
+'use client';
+import { useState } from 'react';
+import Toast from './Toast';
+
+type Customer = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+type Props = {
+  customers: Customer[];
+};
+
+export default function SearchForm({ customers }: Props) {
+  const [customerId, setCustomerId] = useState('');
+  const [origin, setOrigin] = useState('');
+  const [destination, setDestination] = useState('');
+  const [earliestDate, setEarliestDate] = useState('');
+  const [latestDate, setLatestDate] = useState('');
+  const [passengers, setPassengers] = useState(1);
+  const [cabin, setCabin] = useState('ECONOMY');
+  const [loading, setLoading] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+  const [result, setResult] = useState<any>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!customerId || !origin || !destination || !earliestDate || !latestDate) {
+      setToast({ message: 'All fields required', type: 'error' });
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch('/api/search', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-user-email': 'agent@example.com',
+        },
+        body: JSON.stringify({
+          customer: customerId,
+          origin,
+          destination,
+          earliestDate,
+          latestDate,
+          passengers,
+          cabin,
+        }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setToast({ message: 'Search saved', type: 'success' });
+        setResult(data);
+      } else {
+        setToast({ message: data.error || 'Error', type: 'error' });
+      }
+    } catch (err) {
+      setToast({ message: 'Network error', type: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="relative">
+      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <select
+          className="w-full border p-2 rounded"
+          value={customerId}
+          onChange={(e) => setCustomerId(e.target.value)}
+          required
+        >
+          <option value="">Select Customer</option>
+          {customers.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name} ({c.email})
+            </option>
+          ))}
+        </select>
+        <div className="flex gap-2">
+          <input
+            className="w-full border p-2 rounded"
+            placeholder="Origin"
+            value={origin}
+            onChange={(e) => setOrigin(e.target.value)}
+            required
+          />
+          <input
+            className="w-full border p-2 rounded"
+            placeholder="Destination"
+            value={destination}
+            onChange={(e) => setDestination(e.target.value)}
+            required
+          />
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="date"
+            className="w-full border p-2 rounded"
+            value={earliestDate}
+            onChange={(e) => setEarliestDate(e.target.value)}
+            required
+          />
+          <input
+            type="date"
+            className="w-full border p-2 rounded"
+            value={latestDate}
+            onChange={(e) => setLatestDate(e.target.value)}
+            required
+          />
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            className="w-full border p-2 rounded"
+            min={1}
+            value={passengers}
+            onChange={(e) => setPassengers(Number(e.target.value))}
+          />
+          <select
+            className="w-full border p-2 rounded"
+            value={cabin}
+            onChange={(e) => setCabin(e.target.value)}
+          >
+            <option value="ECONOMY">ECONOMY</option>
+            <option value="PREMIUM_ECONOMY">PREMIUM_ECONOMY</option>
+            <option value="BUSINESS">BUSINESS</option>
+            <option value="FIRST">FIRST</option>
+          </select>
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        >
+          {loading ? 'Searching...' : 'Run Search'}
+        </button>
+      </form>
+      {result && (
+        <pre className="mt-4 bg-gray-100 p-2 text-xs overflow-auto">{JSON.stringify(result, null, 2)}</pre>
+      )}
+    </div>
+  );
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { useEffect } from 'react';
+
+type ToastProps = {
+  message: string;
+  type?: 'success' | 'error';
+  onClose: () => void;
+};
+
+export default function Toast({ message, type = 'success', onClose }: ToastProps) {
+  useEffect(() => {
+    const t = setTimeout(onClose, 3000);
+    return () => clearTimeout(t);
+  }, [onClose]);
+
+  const base = 'fixed top-4 right-4 px-4 py-2 rounded shadow text-white transition-opacity';
+  const color = type === 'success' ? 'bg-green-600' : 'bg-red-600';
+
+  return <div className={`${base} ${color}`}>{message}</div>;
+}

--- a/src/models/Customer.ts
+++ b/src/models/Customer.ts
@@ -4,6 +4,7 @@ const customerSchema = new Schema(
   {
     name: { type: String, required: true },
     email: { type: String, required: true },
+    phone: { type: String, required: true },
   },
   { timestamps: true }
 );

--- a/src/models/SearchRequest.ts
+++ b/src/models/SearchRequest.ts
@@ -2,10 +2,18 @@ import { Schema, model, models } from "mongoose";
 
 const searchRequestSchema = new Schema(
   {
-    customer: { type: Schema.Types.ObjectId, ref: "Customer" },
+    customer: { type: Schema.Types.ObjectId, ref: "Customer", required: true },
     origin: { type: String, required: true },
     destination: { type: String, required: true },
-    date: { type: String, required: true },
+    earliestDate: { type: String, required: true },
+    latestDate: { type: String, required: true },
+    passengers: { type: Number, default: 1 },
+    cabin: {
+      type: String,
+      enum: ["ECONOMY", "PREMIUM_ECONOMY", "BUSINESS", "FIRST"],
+      default: "ECONOMY",
+    },
+    status: { type: String, default: "saved" },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- add global layout with navbar and sidebar
- implement dashboard, customer, search and settings pages
- add reusable customer/search forms and toast notifications
- update models and API responses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5d740fdc83328b4ac221931b8224