### PR TITLE
Avoid build-time env validation

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,7 +1,8 @@
-import { env } from '@/env';
+import { getEnv } from '@/env';
 
 export default function SettingsPage() {
   const emailFrom = process.env.EMAIL_FROM || 'not set';
+  const { APP_BASE_URL } = getEnv();
   return (
     <div className="space-y-4">
       <div className="p-4 border rounded">
@@ -19,7 +20,7 @@ export default function SettingsPage() {
       <div className="p-4 border rounded">
         <h2 className="font-semibold">Environment</h2>
         <p>NODE_ENV: {process.env.NODE_ENV}</p>
-        <p>APP_BASE_URL: {env.APP_BASE_URL}</p>
+        <p>APP_BASE_URL: {APP_BASE_URL}</p>
       </div>
     </div>
   );

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,4 +5,6 @@ const envSchema = z.object({
   APP_BASE_URL: z.string().url(),
 });
 
-export const env = envSchema.parse(process.env);
+export function getEnv() {
+  return envSchema.parse(process.env);
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,5 @@
 import mongoose from "mongoose";
-import { env } from "@/env";
+import { getEnv } from "@/env";
 
 type MongooseCache = {
   conn: typeof mongoose | null;
@@ -17,7 +17,8 @@ export async function connect() {
     return cache.conn;
   }
   if (!cache.promise) {
-    cache.promise = mongoose.connect(env.MONGODB_URI);
+    const { MONGODB_URI } = getEnv();
+    cache.promise = mongoose.connect(MONGODB_URI);
   }
   cache.conn = await cache.promise;
   return cache.conn;


### PR DESCRIPTION
## Summary
- Defer environment variable parsing until runtime
- Update database connection and settings page to use lazy env accessor

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab61b85c1083329b6d144b2db0ca74